### PR TITLE
Drop support for ZendX pseudo namespace

### DIFF
--- a/library/Zend/Loader/Autoloader.php
+++ b/library/Zend/Loader/Autoloader.php
@@ -60,11 +60,13 @@ class Zend_Loader_Autoloader
     protected $_internalAutoloader;
 
     /**
-     * @var array Supported namespaces 'Zend' and 'ZendX' by default.
+     * This used to also support the ZendX pseudo namespace which wasn't
+     * really used anywhere in zendframework1.
+     *
+     * @var array Supported namespace 'Zend' by default.
      */
     protected $_namespaces = array(
         'Zend_'  => true,
-        'ZendX_' => true,
     );
 
     /**


### PR DESCRIPTION
This removes support for the ZendX pseudo namespase which was only used for some experimental features that later made it into the main zf1 code base.

As far as I can tell this hasn't been used anywhere for quite a while now.

Please let me know if you'd like me to search for a solution that doesn't drop support for the ZendX pseudo namespace. Dropping support for it seemed like the easiest fix for some of the issues I found during testing but it might be possible to workaround this by overriding the namespacing in my code somewhere. Due to the fact that the loader usually gets instanciated by Zend_Application overriding the namespaces isn't as straight forward as I'd like it to be.