### PR TITLE
Revert "optimize loading plugins - use only composer autoloader"

### DIFF
--- a/library/Zend/Loader/PluginLoader.php
+++ b/library/Zend/Loader/PluginLoader.php
@@ -393,8 +393,6 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
                 $found = true;
                 break;
             }
-			// composer autoload should handle loading a class. class_exists call is enough
-			continue;
 
             $paths     = array_reverse($paths, true);
 


### PR DESCRIPTION
This reverts commit 01f21b2664fd96cf25f82fd5d0546e6f325673dd it looks to me as a premature optimization what is not well tested.

This actually broke setup of the application here,
and keeping this in does not seem to break anything else (I've been using many years `zf1` version in several applications without problems).

----
The helpers used to be loaded from `application/views/helpers` automatically on demand by Zend framework, removing this support breaks applications.

> Message: Plugin by name 'ImageUrl' was not found in the registry; used paths: Zend_View_Helper_: Zend/View/Helper/:/app/application/views/helpers/

A workaround would be to add `application/views/helpers` to composer `classpath` autoloader exists, but that's incompatible change, requiring to make extra changes in projects.

Also, that approach creates another problem: class names may conflict, and composer will pick only first matching class. 

Not particularly with view helpers, but controllers are loaded (to my knowledge) in the same manner:
> Warning: Ambiguous class resolution, "ErrorController" was found in both "application/modules/ccc-grabber/default/controllers/ErrorController.php" and "application/modules/default/controllers/ErrorController.php", the first will be used.
Warning: Ambiguous class resolution, "IndexController" was found in both "application/modules/ccc-grabber/default/controllers/IndexController.php" and "application/modules/default/controllers/IndexController.php", the first will be used.

cc @falkenhawk 
