### PR TITLE
Make the introduced performance optimization for PluginLoader optional

### DIFF
--- a/library/Zend/Loader/PluginLoader.php
+++ b/library/Zend/Loader/PluginLoader.php
@@ -50,6 +50,12 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
     protected static $_includeFileCacheHandler;
 
     /**
+     * Toggle for fallback loader
+     * @var bool
+     */
+    protected static $_useFallbackLoader = true;
+
+    /**
      * Instance loaded plugin paths
      *
      * @var array
@@ -393,8 +399,10 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
                 $found = true;
                 break;
             }
-			// composer autoload should handle loading a class. class_exists call is enough
-			continue;
+            if (!self::$_useFallbackLoader) {
+                // composer autoload should handle loading a class. class_exists call is enough
+                continue;
+            }
 
             $paths     = array_reverse($paths, true);
 
@@ -504,5 +512,17 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
             $line = "<?php include_once '$incFile'?>\n";
             fwrite(self::$_includeFileCacheHandler, $line, strlen($line));
         }
+    }
+
+    /**
+     * Set usage of fallback loader (enabled by default)
+     * You may disable it with Zend_Loader_PluginLoader::useFallbackLoader(false)
+     * to depend solely on composer's autoloader (for performance) - if your code structure supports that
+     *
+     * @param bool $flag
+     */
+    public static function useFallbackLoader($flag)
+    {
+        self::$_useFallbackLoader = (bool)$flag;
     }
 }


### PR DESCRIPTION
- restore original PluginLoader behavior by default
- introduce static Zend_Loader_PluginLoader::useFallbackLoader(false) toggle to disable the fallback and depend solely on composer's autoloader (for performance) - if your code structure supports that ( https://github.com/zf1s/zend-loader/pull/2#issuecomment-489651050 )